### PR TITLE
Gsa 87 add game details page

### DIFF
--- a/src/client/src/app/app.module.ts
+++ b/src/client/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { MaterialModule } from './material/material.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MerchDetailsComponent } from './components/merch-details/merch-details.component';
+import { UserGameDetailsComponent } from './modules/games/components/user-game-details/user-game-details.component';
 
 const config: SocketIoConfig = { url: !environment.production ? 'http://localhost:3000/' : '', options: {} };
 
@@ -48,6 +49,7 @@ const config: SocketIoConfig = { url: !environment.production ? 'http://localhos
     MerchComponent,
     SidebarComponent,
     MerchDetailsComponent,
+    UserGameDetailsComponent,
 
   ],
   imports: [

--- a/src/client/src/app/app.module.ts
+++ b/src/client/src/app/app.module.ts
@@ -30,7 +30,6 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { MaterialModule } from './material/material.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MerchDetailsComponent } from './components/merch-details/merch-details.component';
-import { UserGameDetailsComponent } from './modules/games/components/user-game-details/user-game-details.component';
 
 const config: SocketIoConfig = { url: !environment.production ? 'http://localhost:3000/' : '', options: {} };
 
@@ -49,7 +48,6 @@ const config: SocketIoConfig = { url: !environment.production ? 'http://localhos
     MerchComponent,
     SidebarComponent,
     MerchDetailsComponent,
-    UserGameDetailsComponent,
 
   ],
   imports: [

--- a/src/client/src/app/modules/games/components/user-game-details/user-game-details.component.html
+++ b/src/client/src/app/modules/games/components/user-game-details/user-game-details.component.html
@@ -1,0 +1,1 @@
+<p>user-game-details works!</p>

--- a/src/client/src/app/modules/games/components/user-game-details/user-game-details.component.ts
+++ b/src/client/src/app/modules/games/components/user-game-details/user-game-details.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-user-game-details',
+  templateUrl: './user-game-details.component.html',
+  styleUrls: ['./user-game-details.component.scss']
+})
+export class UserGameDetailsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/client/src/app/modules/games/module-games.module.ts
+++ b/src/client/src/app/modules/games/module-games.module.ts
@@ -16,6 +16,7 @@ import { CurrencyMaskModule } from 'ng2-currency-mask';
 import { MatSnackBarModule } from '@angular/material/snack-bar'
 import { MatCardModule } from '@angular/material/card';
 import { UsersGamesListComponent } from './components/users-games-list/users-games-list.component';
+import { UserGameDetailsComponent } from './components/user-game-details/user-game-details.component';
 
 
 
@@ -23,6 +24,7 @@ import { UsersGamesListComponent } from './components/users-games-list/users-gam
   declarations: [
     AddGameComponent,
     UsersGamesListComponent,
+    UserGameDetailsComponent,
 
   ],
   imports: [

--- a/src/client/src/app/modules/games/routing.module.ts
+++ b/src/client/src/app/modules/games/routing.module.ts
@@ -4,11 +4,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { AddGameComponent } from './components/add-game/add-game.component';
 import { PageGamesComponent } from 'src/app/pages/page-games/page-games.component';
 import { UsersGamesListComponent } from './components/users-games-list/users-games-list.component';
+import { UserGameDetailsComponent } from './components/user-game-details/user-game-details.component';
 
 const routes: Routes = [
   {path: '', component: PageGamesComponent},
   {path: 'users-games-list', component: UsersGamesListComponent},
   {path: 'create-game', component: AddGameComponent},
+  {path: 'game-details', component: UserGameDetailsComponent},
 ]
 
 


### PR DESCRIPTION
## Changes
1. Generate game details page by running `ng g c modules/games/components/user-game-details --module ../app`
2. Move UserGameDetailsComponent to Games Module from the app module

## Purpose
Add a page so a user can view more details about the selected game

## Approach

## Learning

Closes #87 