### PR TITLE
Gsa 104 clean ngrx store

### DIFF
--- a/src/client/src/app/modules/games/store/game.selectors.ts
+++ b/src/client/src/app/modules/games/store/game.selectors.ts
@@ -2,7 +2,7 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {AppState} from '../../../store';
 import * as fromGame from './game.reducer';
 
-const gameFeatureSelector = createFeatureSelector<AppState, fromGame.State>(fromGame.gameFeatureKey)
+const gameFeatureSelector = createFeatureSelector<fromGame.State>(fromGame.gameFeatureKey)
 
 const {
   selectIds,

--- a/src/client/src/app/store/index.ts
+++ b/src/client/src/app/store/index.ts
@@ -7,21 +7,18 @@ import {
 } from '@ngrx/store';
 import { environment } from '../../environments/environment';
 import * as fromUser from './reducers/user/user.reducer';
-import * as fromGame from '../modules/games/store/game.reducer';
 import * as fromMerch from './reducers/merch/merch.reducer';
 
 
 export interface AppState {
 
   [fromUser.userFeatureKey]: fromUser.State;
-  [fromGame.gameFeatureKey]: fromGame.State;
   [fromMerch.merchFeatureKey]: fromMerch.State;
 }
 
 export const reducers: ActionReducerMap<AppState> = {
 
   [fromUser.userFeatureKey]: fromUser.reducer,
-  [fromGame.gameFeatureKey]: fromGame.reducer,
   [fromMerch.merchFeatureKey]: fromMerch.reducer,
 };
 


### PR DESCRIPTION
## Changes
1. Remove game reducer from index.ts
2. remove AppState from game selector

## Purpose
The game state should not initially load in the redux store.

## Approach

## Learning

Closes #104 