### PR TITLE
Gsa 116 add game resolver

### DIFF
--- a/src/client/src/app/modules/games/gamedetails.resolver.ts
+++ b/src/client/src/app/modules/games/gamedetails.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@angular/core";
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from "@angular/router";
+import { Store } from "@ngrx/store";
+import { Observable, of } from "rxjs";
+import { loadGames } from "../games/store/game.actions";
+
+
+@Injectable({
+  providedIn: 'root'
+})
+
+export class GameDetailsResolver implements Resolve<any>{
+
+  constructor(private store: Store){}
+
+  resolve(route:ActivatedRouteSnapshot, state: RouterStateSnapshot):Observable<any>{
+    this.store.dispatch(loadGames())
+    return of(null)
+  }
+}

--- a/src/client/src/app/modules/games/routing.module.ts
+++ b/src/client/src/app/modules/games/routing.module.ts
@@ -6,15 +6,17 @@ import { PageGamesComponent } from 'src/app/pages/page-games/page-games.componen
 import { UsersGamesListComponent } from './components/users-games-list/users-games-list.component';
 import { UserGameDetailsComponent } from './components/user-game-details/user-game-details.component';
 import { RolesGuard } from 'src/app/guards/roles.guard';
+import { GameDetailsResolver } from './gamedetails.resolver';
 
 const routes: Routes = [
   {path: '', component: PageGamesComponent},
   {path: 'users-games-list', component: UsersGamesListComponent},
   {path: 'create-game', component: AddGameComponent,
     canActivate: [RolesGuard], data:{roles:["ADMIN"]}},
-  {path: 'game-details/:id', component: UserGameDetailsComponent},
-]
+  {path: 'game-details/:id', component: UserGameDetailsComponent,
+    resolve: {GameDetailsResolver}},
 
+]
 
 @NgModule({
   declarations: [],


### PR DESCRIPTION
## Changes
1. Add a game resolver ts with basic function
2. Add 'resolve' property in the game routing module, specifically for 'game-details/:id' route

## Purpose
Add a resolver to pre-fetch games data before the route navigation finish. This will avoid seeing an empty screen if a webpage, for example, is refreshed.

## Approach

## Learning
* https://dev.to/this-is-angular/how-to-use-angular-resolver-to-prefetch-beers-into-the-party-49g3
* https://stackblitz.com/edit/prefetch-data-with-resolver-angular?file=src%2Fapp%2Fresolvers%2Fbeer.resolver.service.ts
* https://angular.io/api/router/Resolve

Closes #113 