### PR TITLE
feat(RouteEffects): add effect to route on loginSuccess

### DIFF
--- a/src/client/src/app/app.module.ts
+++ b/src/client/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { MaterialModule } from './material/material.module';
 import { MerchDetailsComponent } from './components/merch-details/merch-details.component';
 import { MainNavComponent } from './main-nav/main-nav.component';
 import { StoreRouterConnectingModule } from '@ngrx/router-store';
+import { RouteEffects } from './store/effects/route/route.effects';
 
 
 
@@ -61,7 +62,7 @@ const config: SocketIoConfig = { url: !environment.production ? 'http://localhos
     StoreModule.forFeature(fromUser.userFeatureKey, fromUser.reducer),
     EffectsModule.forRoot([UserEffects]),
     SocketIoModule.forRoot(config),
-    EffectsModule.forRoot([UserEffects, MerchEffects]),
+    EffectsModule.forRoot([UserEffects, MerchEffects, RouteEffects]),
     StoreModule.forFeature(fromMerch.merchFeatureKey, fromMerch.reducer),
     FaModule,
     BrowserAnimationsModule,

--- a/src/client/src/app/store/effects/route/route.effects.spec.ts
+++ b/src/client/src/app/store/effects/route/route.effects.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable } from 'rxjs';
+
+import { RouteEffects } from './route.effects';
+
+describe('RouteEffects', () => {
+  let actions$: Observable<any>;
+  let effects: RouteEffects;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        RouteEffects,
+        provideMockActions(() => actions$)
+      ]
+    });
+
+    effects = TestBed.inject(RouteEffects);
+  });
+
+  it('should be created', () => {
+    expect(effects).toBeTruthy();
+  });
+});

--- a/src/client/src/app/store/effects/route/route.effects.ts
+++ b/src/client/src/app/store/effects/route/route.effects.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Router } from '@angular/router';
+import { map, tap } from 'rxjs/operators';
+import { loginUserSuccess } from '../../actions/user/user.actions';
+
+
+
+@Injectable()
+export class RouteEffects {
+
+  loginRoute$ = createEffect(() => this.actions$.pipe(ofType(loginUserSuccess),
+  tap((action) => this.router.navigate(['games/users-games-list']))),
+  {dispatch: false})
+
+  constructor(
+    private actions$: Actions,
+    private router: Router,
+    ) {}
+
+}


### PR DESCRIPTION
## Changes
1. `ng g effect`
2.  create effect in routeEffects

## Purpose
trigger routing of user after the loginSuccess action

## Approach
use a created effect with out dispatching any additional actions

Closes #144 