### PR TITLE
132 create admin game page

### DIFF
--- a/src/client/src/app/main-nav/main-nav.component.html
+++ b/src/client/src/app/main-nav/main-nav.component.html
@@ -10,7 +10,8 @@
       <div fxShow="true" fxHide.lt-md >
         <!-- The following menu items will be hidden on both SM and XS screen sizes -->
         <mat-menu #topgameMenu="matMenu">
-          <button mat-menu-item routerLink="games/users-games-list">All Games</button>
+          <button mat-menu-item routerLink="games/users-games-list">All Games (For Users) </button>
+          <button mat-menu-item routerLink="games/admin-games-list">All Games (For Admins only)</button>
           <button mat-menu-item routerLink="games/create-game">Add Game</button>
           <button mat-menu-item routerLink="join-game" >Play Game</button>
           </mat-menu>
@@ -40,7 +41,8 @@
       <mat-nav-list>
         <a (click)="sidenav.toggle()" href="" mat-list-item><mat-icon>clear</mat-icon></a>
         <mat-menu #gameMenu="matMenu">
-          <button mat-menu-item routerLink="games/users-games-list" (click)="sidenav.toggle()">All Games</button>
+          <button mat-menu-item routerLink="games/users-games-list" (click)="sidenav.toggle()">All Games (For Users)</button>
+          <button mat-menu-item routerLink="games/admin-games-list" (click)="sidenav.toggle()">All Games (For Admins only)</button>
           <button mat-menu-item routerLink="games/create-game" (click)="sidenav.toggle()">Add Game</button>
           <button mat-menu-item routerLink="join-game" (click)="sidenav.toggle()">Play Game</button>
           </mat-menu>
@@ -62,7 +64,7 @@
         <!-- <a href="#" mat-list-item>Sign Up</a>
         <a href="#" mat-list-item>Login</a>
         <a href="#"mat-list-item>Logout</a> -->
-        
+
         <mat-menu #profileMenu="matMenu">
           <button mat-menu-item routerLink="login" (click)="sidenav.toggle()">Login</button>
           <button mat-menu-item routerLink="register" (click)="sidenav.toggle()">Sign Up</button>
@@ -73,7 +75,7 @@
           <mat-icon>unfold_more</mat-icon></a>
       </mat-nav-list>
     </mat-sidenav>
-    
+
     <mat-sidenav-content fxFlexFill>
       <div class="welcome">Welcome to Problox</div>
       <router-outlet></router-outlet>

--- a/src/client/src/app/modules/games/components/admin-games-list/admin-games-list.component.html
+++ b/src/client/src/app/modules/games/components/admin-games-list/admin-games-list.component.html
@@ -1,0 +1,1 @@
+<p>admin-games-list works!</p>

--- a/src/client/src/app/modules/games/components/admin-games-list/admin-games-list.component.ts
+++ b/src/client/src/app/modules/games/components/admin-games-list/admin-games-list.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-admin-games-list',
+  templateUrl: './admin-games-list.component.html',
+  styleUrls: ['./admin-games-list.component.scss']
+})
+export class AdminGamesListComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/client/src/app/modules/games/module-games.module.ts
+++ b/src/client/src/app/modules/games/module-games.module.ts
@@ -12,6 +12,7 @@ import { material } from 'src/app/material/material.module';
 import { UsersGamesListComponent } from './components/users-games-list/users-games-list.component';
 import { UserGameDetailsComponent } from './components/user-game-details/user-game-details.component';
 import { RouterModule } from '@angular/router';
+import { AdminGamesListComponent } from './components/admin-games-list/admin-games-list.component';
 
 
 
@@ -20,6 +21,7 @@ import { RouterModule } from '@angular/router';
     AddGameComponent,
     UsersGamesListComponent,
     UserGameDetailsComponent,
+    AdminGamesListComponent,
 
   ],
   imports: [

--- a/src/client/src/app/modules/games/routing.module.ts
+++ b/src/client/src/app/modules/games/routing.module.ts
@@ -7,10 +7,12 @@ import { UsersGamesListComponent } from './components/users-games-list/users-gam
 import { UserGameDetailsComponent } from './components/user-game-details/user-game-details.component';
 import { RolesGuard } from 'src/app/guards/roles.guard';
 import { GameDetailsResolver } from './gamedetails.resolver';
+import { AdminGamesListComponent } from './components/admin-games-list/admin-games-list.component';
 
 const routes: Routes = [
   {path: '', component: PageGamesComponent},
   {path: 'users-games-list', component: UsersGamesListComponent},
+  {path: 'admin-games-list', component: AdminGamesListComponent},
   {path: 'create-game', component: AddGameComponent,
     canActivate: [RolesGuard], data:{roles:["ADMIN"]}},
   {path: 'game-details/:id', component: UserGameDetailsComponent,


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Run `ng g c modules/games/components/users-games-list --module ../module-games` to generate admin-games-list component. 
2. Add route to AdminGamesListComponent
3. Add buttons to main and side navbar to navigate to the AdminGamesListComponent

## Purpose
By creating an admin page for the games list, the admin will be able to modify game details on the front end 

## Approach

## Learning

Closes #132 